### PR TITLE
Add assume_PSD=True to ex_ante_tracking_error's quad_form

### DIFF
--- a/pypfopt/objective_functions.py
+++ b/pypfopt/objective_functions.py
@@ -238,7 +238,7 @@ def ex_ante_tracking_error(w, cov_matrix, benchmark_weights):
         value of the objective function OR objective function expression
     """
     relative_weights = w - benchmark_weights
-    tracking_error = cp.quad_form(relative_weights, cov_matrix)
+    tracking_error = cp.quad_form(relative_weights, cov_matrix, assume_PSD=True)
     return _objective_value(w, tracking_error)
 
 

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -116,6 +116,25 @@ def test_ex_ante_tracking_error():
     np.testing.assert_almost_equal(te, 0.028297778946639436)
 
 
+def test_ex_ante_tracking_error_assumes_psd():
+    # ex_ante_tracking_error is the only quad_form-based objective in this
+    # module that didn't pass assume_PSD=True (unlike portfolio_variance,
+    # sharpe_ratio and quadratic_utility), even though cov_matrix is
+    # documented/used the same way as those. Passing assume_PSD=True skips
+    # cvxpy's own PSD-certification check, which is known to fail for
+    # legitimately PSD-but-ill-conditioned covariance matrices on some
+    # cvxpy/solver versions (see #631 for a user-reported case with a custom
+    # quad_form-based objective). This just checks the numeric result is
+    # unchanged for a well-conditioned matrix, i.e. the fix is behavior
+    # preserving in the normal case.
+    bm_w = np.ones(5) / 5
+    w = np.array([0.4, 0.4, 0, 0, 0])
+    S = pd.DataFrame(np.eye(5))
+
+    te = objective_functions.ex_ante_tracking_error(w, S, bm_w)
+    np.testing.assert_almost_equal(te, 0.2)
+
+
 def test_ex_post_tracking_error():
     df = get_data()
     rets = returns_from_prices(df).dropna()


### PR DESCRIPTION
## What this fixes

`objective_functions.py` has four `cp.quad_form(...)` call sites over a covariance matrix. Three of them (`portfolio_variance`, `sharpe_ratio`, `quadratic_utility`) pass `assume_PSD=True`, which skips cvxpy's own numerical PSD-certification check on the matrix — the right call, since `cov_matrix` is PSD by construction even when it's numerically ill-conditioned (small sample size relative to number of assets, near-duplicate assets, etc.).

`ex_ante_tracking_error` was the one outlier missing it, despite taking the same kind of `cov_matrix` argument used the same way. This is the exact failure class reported in #631 (`cvxpy note: ... trying to certify that a matrix is positive semi-definite ... replace the matrix A by cvxpy.psd_wrap(A)`), for a user's own `quad_form`-based objective modeled on this codebase's pattern.

## Honesty about verification

I was not able to force this exact PSD-certification error against the current cvxpy (1.9.2) with any covariance matrix I constructed (including exactly-singular, ill-conditioned, and rank-deficient ones) — cvxpy appears to have become more lenient about this over time. So this isn't a "fails on main, passes with fix" reproduction; it's a defensive consistency fix that matches the established pattern used by the sibling objective functions in this same file, and directly addresses the failure mode described in #631.

## Test log

```
$ pytest tests/test_objective_functions.py -v
...
12 passed in 6.30s

$ pytest tests/test_efficient_frontier.py -q
75 passed, 6 warnings in 39.46s

$ black --check pypfopt/objective_functions.py tests/test_objective_functions.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.
```

Added `test_ex_ante_tracking_error_assumes_psd` confirming the numeric output is unchanged for a well-conditioned matrix (i.e. the fix is behavior-preserving in the normal case), alongside the existing `test_ex_ante_tracking_error` / `test_ex_ante_tracking_error_dummy` tests which both still pass unmodified.